### PR TITLE
Fix refresh bug for flows that don't have a client_secret.

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -158,7 +158,7 @@ export default class OAuth2 {
         grant_type: 'refresh_token',
         refresh_token: previousToken.refreshToken
       };
-      if ((this.options as any).clientSecret !== undefined) {
+      if ((this.options as any).clientSecret === undefined) {
         // If there is no secret, it means we need to send the clientId along
         // in the body.
         body.client_id = this.options.clientId;


### PR DESCRIPTION
Refresh never worked for authorization_code in this manner.