### PR TITLE
Refactor things a bit.

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -17,6 +17,7 @@ export default class OAuth2 {
 
     // Backwards compatibility
     if (options.accessToken) {
+      // eslint-disable-next-line no-console
       console.warn(
         '[fetch-mw-oauth2] Specifying accessToken via the options argument ' +
         'in the constructor of OAuth2 is deprecated. Please supply the ' +

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -10,7 +10,7 @@ export default class OAuth2 {
 
   constructor(options: OAuth2Options & Partial<Token>, token?: Token) {
 
-    if (!options.grantType && !token) {
+    if (!options.grantType && !token && !options.accessToken) {
       throw new Error('If no grantType is specified, a token must be provided');
     }
     this.options = options;
@@ -176,8 +176,8 @@ export default class OAuth2 {
           };
           break;
         default :
-          if (typeof (this.options as any).grantType === 'string') {
-            throw new Error('Unknown grantType: ' + (this.options as any).grantType);
+          if (typeof this.options.grantType === 'string') {
+            throw new Error('Unknown grantType: ' + this.options.grantType);
           } else {
             throw new Error('Cannot obtain an access token if no "grantType" is specified');
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,18 +44,6 @@ type PasswordGrantOptions = {
   password: string,
 
   /**
-   * If there's a previously valid access token, use this.
-   *
-   * If specified, it won't use the standard OAuth2 flow unless the token is invalid.
-   */
-  accessToken?: string,
-
-  /**
-   * Previously obtained refresh token (if any)
-   */
-  refreshToken?: string,
-
-  /**
    * Callback to trigger when a new access/refresh token pair was obtained.
    */
   onTokenUpdate?: (token: Token) => void,
@@ -94,18 +82,6 @@ type ClientCredentialsGrantOptions = {
    * List of OAuth2 scopes
    */
   scope?: string[],
-
-  /**
-   * If there's a previously valid access token, use this.
-   *
-   * If specified, it won't use the standard OAuth2 flow unless the token is invalid.
-   */
-  accessToken?: string,
-
-  /**
-   * Previously obtained refresh token (if any)
-   */
-  refreshToken?: string,
 
   /**
    * Callback to trigger when a new access/refresh token pair was obtained.
@@ -151,18 +127,6 @@ type AuthorizationCodeGrantOptions = {
   code: string,
 
   /**
-   * If there's a previously valid access token, use this.
-   *
-   * If specified, it won't use the standard OAuth2 flow unless the token is invalid.
-   */
-  accessToken?: string,
-
-  /**
-   * Previously obtained refresh token (if any)
-   */
-  refreshToken?: string,
-
-  /**
    * Callback to trigger when a new access/refresh token pair was obtained.
    */
   onTokenUpdate?: (token: Token) => void,
@@ -201,11 +165,6 @@ type RefreshOnlyGrantOptions = {
    * Previously obtained access token
    */
   accessToken: string,
-
-  /**
-   * Previously obtained refresh token (if any)
-   */
-  refreshToken?: string,
 
   /**
    * Callback to trigger when a new access/refresh token pair was obtained.

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,18 +153,13 @@ type AuthorizationCodeGrantOptions = {
  * If a refresh or tokenEndpoint are not supplied, the token will never get refreshed.
  */
 type RefreshOnlyGrantOptions = {
-  grantType: undefined,
+  grantType: never,
 
   /**
    * OAuth2 client id
    */
   clientId: string,
   tokenEndpoint: string,
-
-  /**
-   * Previously obtained access token
-   */
-  accessToken: string,
 
   /**
    * Callback to trigger when a new access/refresh token pair was obtained.
@@ -204,4 +199,3 @@ export type AccessTokenRequest = {
   client_id: string,
   code_verifier?: string,
 };
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,7 +153,7 @@ type AuthorizationCodeGrantOptions = {
  * If a refresh or tokenEndpoint are not supplied, the token will never get refreshed.
  */
 type RefreshOnlyGrantOptions = {
-  grantType: never,
+  grantType: undefined,
 
   /**
    * OAuth2 client id


### PR DESCRIPTION
This is a BC break. If the OAuth2 object is setup with an existing
token, it needs to be specified as the second argument.