### PR TITLE
Automatically schedule refreshes.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,22 @@
  * Token information
  */
 export type OAuth2Token = {
+
+  /**
+   * OAuth2 Access Token
+   */
   accessToken: string,
+
+  /**
+   * When the Access Token expires.
+   *
+   * This is expressed as a unix timestamp in milliseconds.
+   */
   expiresAt: number | null,
+
+  /**
+   * OAuth2 refresh token
+   */
   refreshToken: string | null,
 };
 


### PR DESCRIPTION
If we have knowledge of when the accessToken will expire, we will
automatically trigger a refresh 1 minute before expiry.

This is going to be more reliable and faster than just letting it expire,
wait for a 401 and refresh on error.