### PR TITLE
Fixed docs when creating new client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ To get started, set up the Client class.
 
 
 ```typescript
-import { OAuth2Client } from 'fetch-mw-oauth2';
+import OAuth2Client from 'fetch-mw-oauth2';
 
-const client = new Client({
+const client = new OAuth2Client({
 
   // The base URI of your OAuth2 server
   server: 'https://my-auth-server/',


### PR DESCRIPTION
The docs showed attempting to destructure `OAuth2Client` off the library, and using `Client` to start a new class. This doesn't work and it seems `fetch-mw-oauth2` just has a default export, and that should be used to start a new class. 

```javascript
import OAuth2Client from 'fetch-mw-oauth2';

const client = new OAuth2Client({
  
})
```